### PR TITLE
Fix: Unwanted merge of Entity due to incorrect OriginEntityCode

### DIFF
--- a/docs/4.1.2-release-notes.md
+++ b/docs/4.1.2-release-notes.md
@@ -4,3 +4,4 @@
 ### Fix
 - Data logo in overview not showing
 - Log a message when an exception occurs
+- Unwanted merge due to incorrect EntityType in OriginEntityCode

--- a/src/WebExternalSearchProvider.cs
+++ b/src/WebExternalSearchProvider.cs
@@ -251,7 +251,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
 
         private EntityCode GetOriginEntityCode(IExternalSearchQueryResult<WebResult> resultItem, IExternalSearchRequest request)
         {
-            return new EntityCode(EntityType.Organization, this.GetCodeOrigin(), request.EntityMetaData.OriginEntityCode.Value);
+            return new EntityCode(request.EntityMetaData.EntityType, this.GetCodeOrigin(), request.EntityMetaData.OriginEntityCode.Value);
         }
 
         private CodeOrigin GetCodeOrigin()


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: https://dev.azure.com/CluedIn-io/CluedIn/_workitems/edit/36598

## How has it been tested? <!-- Remove if not needed -->
Locally with Docker

2 Entities with same data processed with Different Entity Types
![image](https://github.com/user-attachments/assets/e93c2839-c155-46d2-8661-8b1d31aa3ffe)

Both Enriched but didn't merge
![image](https://github.com/user-attachments/assets/ea64a479-ef51-4cfa-82c2-d650e8f167d5)
![image](https://github.com/user-attachments/assets/6cbfd244-bc55-4cf1-9652-66c00734f992)

