### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -3,3 +3,4 @@
 - Terminology changes
 
 ### Fix
+- Fix topology not showing data from enricher

--- a/src/WebExternalSearchProvider.cs
+++ b/src/WebExternalSearchProvider.cs
@@ -174,8 +174,6 @@ namespace CluedIn.ExternalSearch.Providers.Web
                 }
             };
             
-            clue.Data.EntityData.Codes.Add(request.EntityMetaData.OriginEntityCode);
-
             this.PopulateMetadata(context, clue.Data.EntityData, resultItem, request);
 
             if (clue.Data.EntityData.Properties.ContainsKey(WebVocabulary.Website.Logo))
@@ -301,7 +299,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
             metadata.OriginEntityCode       = code;
             metadata.Uri                    = orgWebSite.RequestUri;
             metadata.Description            = orgWebSite.WebsiteDescription;
-
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
             //// Aliases
             if (orgWebSite.SchemaOrgOrganization != null)
             {

--- a/src/WebExternalSearchProvider.cs
+++ b/src/WebExternalSearchProvider.cs
@@ -164,10 +164,17 @@ namespace CluedIn.ExternalSearch.Providers.Web
         {
             var resultItem = result.As<WebResult>();
 
-            var code = request.EntityMetaData.OriginEntityCode;
-
-            var clue = new Clue(code, context.Organization);
-            clue.Data.OriginProviderDefinitionId = this.Id;
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "website", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+            
+            var clue = new Clue(code, context.Organization)
+            {
+                Data =
+                {
+                   OriginProviderDefinitionId = Id
+                }
+            };
+            
+            clue.Data.EntityData.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             this.PopulateMetadata(context, clue.Data.EntityData, resultItem, request);
 
@@ -283,13 +290,15 @@ namespace CluedIn.ExternalSearch.Providers.Web
 
         private void PopulateMetadata(ExecutionContext context, IEntityMetadata metadata, IExternalSearchQueryResult<WebResult> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "website", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             var orgWebSite  = resultItem.Data.GetOrganizationWebsiteMetadata(context);
 
             var name = orgWebSite.Name;
 
             metadata.EntityType             = request.EntityMetaData.EntityType;
             metadata.Name                   = request.EntityMetaData.Name;
-            metadata.OriginEntityCode       = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode       = code;
             metadata.Uri                    = orgWebSite.RequestUri;
             metadata.Description            = orgWebSite.WebsiteDescription;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Data from web enricher is now showing in Topology screen
![image](https://github.com/user-attachments/assets/5cce3ac9-0f5b-4ae0-872d-4c20ab42ee89)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
