### PR TITLE
fix: Set website vocabulary key as mandatory

### DIFF
--- a/docs/4.4.2-release-notes.md
+++ b/docs/4.4.2-release-notes.md
@@ -1,0 +1,2 @@
+### Fix
+- Set Website Vocabulary Key as mandatory

--- a/src/WebExternalSearchConstants.cs
+++ b/src/WebExternalSearchConstants.cs
@@ -66,7 +66,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
                 {
                     DisplayName = "Website Vocabulary Key",
                     Type = "vocabularyKeySelector",
-                    IsRequired = false,
+                    IsRequired = true,
                     Name = KeyName.WebsiteKey,
                     Help = "The vocabulary key that contains the websites of companies you want to enrich (e.g., organization.website).",
                 },


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48882](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48882)

After updating:
![image](https://github.com/user-attachments/assets/c9bfad7d-d600-4284-b55f-c7ac8f197745)


## How has it been tested? <!-- Remove if not needed -->
Manually in local

