### PR TITLE
fix: Add more request headers to allow access to certain sites

### DIFF
--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -3,8 +3,8 @@
 
 ### Fix
 - Update unable to access website exception message
+- Add more request headers to allow access to certain sites
 
 ### Chore
 - Move projects into src
 - Update azure pipeline
-

--- a/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
@@ -143,11 +143,24 @@ namespace CluedIn.ExternalSearch.Providers.Web
             else
                 throw new Exception("Invalid query uri: " + uriText);
 
-            var client      = new RestClient(uri);
-            var request     = new RestRequest("/", Method.GET);
+            var client = new RestClient(uri)
+            {
+                UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                AutomaticDecompression = true
+            };
+
+            client.ConfigureWebRequest(r => r.KeepAlive = true);
+            var request = new RestRequest("/");
 
             request.AddHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
-            request.AddHeader("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36");
+            request.AddHeader("Accept-Language", "en-US,en;q=0.9");
+            request.AddHeader("Cache-Control", "no-cache");
+            request.AddHeader("Pragma", "no-cache");
+            request.AddHeader("Upgrade-Insecure-Requests", "1");
+            request.AddHeader("Sec-Fetch-Site", "none");
+            request.AddHeader("Sec-Fetch-Mode", "navigate");
+            request.AddHeader("Sec-Fetch-User", "?1");
+            request.AddHeader("Sec-Fetch-Dest", "document");
 
             var response    = client.Get(request);
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#52488](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/52488)

Some enrichments failed because the site could not be accessed. Adding more headers to the request may help, but it cannot guarantee coverage of all site requirements.
I will also create another PR in the core to fix the JSON-LD deserialization issue, which is another cause of enrichment failures.

## How has it been tested? <!-- Remove if not needed -->
Manually in local

