### PR TITLE
fix: Display logo vocabulary key value in enricher data tab

### DIFF
--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -4,6 +4,7 @@
 ### Fix
 - Update unable to access website exception message
 - Add more request headers to allow access to certain sites
+- Display Logo vocabulary key value in enricher data tab
 
 ### Chore
 - Move projects into src

--- a/src/ExternalSearch.Providers.Web/Vocabularies/WebsiteVocabulary.cs
+++ b/src/ExternalSearch.Providers.Web/Vocabularies/WebsiteVocabulary.cs
@@ -28,7 +28,7 @@ namespace CluedIn.ExternalSearch.Providers.Web.Vocabularies
 
             this.Description                = this.Add(new VocabularyKey("Description"));
             this.Title                      = this.Add(new VocabularyKey("Title"));
-            this.Logo                       = this.Add(new VocabularyKey("Logo", VocabularyKeyVisibility.Hidden));
+            this.Logo                       = this.Add(new VocabularyKey("Logo"));
             this.CopyrightEntity            = this.Add(new VocabularyKey("CopyrightEntity"));
             this.WebsiteDescription         = this.Add(new VocabularyKey("WebsiteDescription"));
             this.Name                       = this.Add(new VocabularyKey("Name"));


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#53176](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/53176)

Before this update, the vocabulary key is being displayed as `website.` with no value in Data tab
<img width="1905" height="938" alt="image" src="https://github.com/user-attachments/assets/86e2dde6-81b1-4a07-9a5c-e976a171f55e" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local

