### PR TITLE
fix: Display logo instead of broken image in preview tab

### DIFF
--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -5,6 +5,7 @@
 - Update unable to access website exception message
 - Add more request headers to allow access to certain sites
 - Display Logo vocabulary key value in enricher data tab
+- Display logo instead of broken image in preview tab
 
 ### Chore
 - Move projects into src

--- a/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
@@ -224,6 +224,11 @@ namespace CluedIn.ExternalSearch.Providers.Web
 
                         clue.Details.RawData.Add(rawDataPart);
                         clue.Data.EntityData.PreviewImage = new ImageReferencePart(rawDataPart);
+                        clue.Data.EntityData.Properties[WebVocabulary.Website.Logo] = orgWebSite.Logo.ToString();
+                    }
+                    else
+                    {
+                        clue.Data.EntityData.Properties[WebVocabulary.Website.Logo] = string.Empty;
                     }
                 }
             }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#53362

Note: the `website.logo` column is not the static logoPreview column we created recently
Before:
<img width="2753" height="986" alt="image" src="https://github.com/user-attachments/assets/ce0c74b1-c662-4525-908c-db8cde15ee8f" />

After:
<img width="1924" height="943" alt="image" src="https://github.com/user-attachments/assets/099a1437-f77b-4ae4-9ab3-ada493e8f637" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local
