### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +24,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Processing" Version="$(_CluedIn)" />

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.Web.Provider/ExternalSearch.Providers.Web.Provider.csproj
+++ b/src/ExternalSearch.Providers.Web.Provider/ExternalSearch.Providers.Web.Provider.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<PackageReference Include="CluedIn.Core" />
-		<PackageReference Include="ComponentHost" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ExternalSearch.Providers.Web/ExternalSearch.Providers.Web.csproj
+++ b/src/ExternalSearch.Providers.Web/ExternalSearch.Providers.Web.csproj
@@ -12,7 +12,4 @@
     <PackageReference Include="CluedIn.Processing.Web" />
     <PackageReference Include="CluedIn.Processing.Web.TechnologyDetection" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.Web/Model/WebRestResponse.cs
+++ b/src/ExternalSearch.Providers.Web/Model/WebRestResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Newtonsoft.Json;
@@ -6,17 +6,14 @@ using RestSharp;
 
 namespace CluedIn.ExternalSearch.Providers.Web.Model
 {
-	public class WebRestResponse : IRestResponse
+	public class WebRestResponse : RestResponse
 	{
 		public WebRestResponse()
 		{
-			this.Cookies = new List<RestResponseCookie>();
-			this.Headers = new List<Parameter>();
 		}
 
-		public WebRestResponse(IRestResponse response)
+		public WebRestResponse(RestResponse response)
 		{
-			this.Request           = response.Request;
 			this.ContentType       = response.ContentType;
 			this.ContentLength     = response.ContentLength;
 			this.ContentEncoding   = response.ContentEncoding;
@@ -32,51 +29,5 @@ namespace CluedIn.ExternalSearch.Providers.Web.Model
 			this.ErrorMessage      = response.ErrorMessage;
 			this.ErrorException    = response.ErrorException;
 		}
-
-		[JsonIgnore]
-		public IRestRequest Request { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string ContentType { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public long ContentLength { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string ContentEncoding { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Content { get; set; }
-
-		public HttpStatusCode StatusCode { get; set; }
-
-		public bool IsSuccessful { get; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string StatusDescription { get; set; }
-
-		[JsonIgnore]
-		public byte[] RawBytes { get; set; }
-
-		public Uri ResponseUri { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Server { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public IList<RestResponseCookie> Cookies { get; set; }
-
-		[JsonIgnore]
-		public IList<Parameter> Headers { get; set; }
-
-		public ResponseStatus ResponseStatus { get; set; }
-
-		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string ErrorMessage { get; set; }
-
-		[JsonIgnore]
-		public Exception ErrorException { get; set; }
-
-		public Version ProtocolVersion { get; set; }
 	}
 }

--- a/src/ExternalSearch.Providers.Web/Model/WebResult.cs
+++ b/src/ExternalSearch.Providers.Web/Model/WebResult.cs
@@ -14,7 +14,7 @@ namespace CluedIn.ExternalSearch.Providers.Web.Model
         {
         }
 
-        public WebResult(Uri requestUri, IRestResponse response)
+        public WebResult(Uri requestUri, RestResponse response)
         {
             this.RequestUri   = requestUri;
             this.RestResponse = new WebRestResponse(response);

--- a/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
@@ -153,13 +153,11 @@ namespace CluedIn.ExternalSearch.Providers.Web
             else
                 throw new Exception("Invalid query URL: " + uriText);
 
-            var client = new RestClient(uri)
+            var client = new RestClient(new RestClientOptions(uri)
             {
                 UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-                AutomaticDecompression = true
-            };
-
-            client.ConfigureWebRequest(r => r.KeepAlive = true);
+                AutomaticDecompression = System.Net.DecompressionMethods.All
+            });
             var request = new RestRequest("/");
 
             request.AddHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
@@ -213,7 +211,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
                 {
                     orgWebSite.Logo = new Uri(new Uri(orgWebSite.ResponseUri.AbsoluteUri), orgWebSite.Logo.ToString());
                     var client = new RestClient();
-                    var req = new RestRequest(orgWebSite.Logo.ToString(), Method.GET);
+                    var req = new RestRequest(orgWebSite.Logo.ToString(), Method.Get);
                     req.AddHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
                     req.AddHeader("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36");
 
@@ -278,7 +276,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
         public ConnectionVerificationResult VerifyConnection(ExecutionContext context, IReadOnlyDictionary<string, object> config)
         {
             var client = new RestClient("https://google.com");
-            var request = new RestRequest("/", Method.GET);
+            var request = new RestRequest("/", Method.Get);
 
             request.AddHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
             request.AddHeader("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36");
@@ -288,7 +286,7 @@ namespace CluedIn.ExternalSearch.Providers.Web
             return ConstructVerifyConnectionResponse(response);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{WebExternalSearchConstants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.Xunit2"/>
+        <PackageReference Include="AutoFixture.Xunit3"/>
         <PackageReference Include="coverlet.msbuild"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="Moq"/>
         <PackageReference Include="Shouldly"/>


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- RestSharp updated to 114.0.0: `IRestResponse<T>` → `RestResponse<T>`; `Method.GET` → `Method.Get`; `ExecuteTaskAsync` → `ExecuteAsync`; `new Parameter(..., ParameterType.QueryString)` → `new QueryParameter(...)`; `client.BaseUrl` → configured via `RestClientOptions` at construction