### PR TITLE
fix: Resolve post dotnet upgrade issues

### DIFF
--- a/docs/5.0.0-release-notes.md
+++ b/docs/5.0.0-release-notes.md
@@ -1,0 +1,5 @@
+###
+- - Update enricher version to 5.0.0 to expire cached result
+
+### Fix
+- Resolve RestSharp upgrade causing deserialization issue

--- a/src/ExternalSearch.Providers.Web/Model/WebRestResponse.cs
+++ b/src/ExternalSearch.Providers.Web/Model/WebRestResponse.cs
@@ -1,12 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using Newtonsoft.Json;
 using RestSharp;
 
 namespace CluedIn.ExternalSearch.Providers.Web.Model
 {
-	public class WebRestResponse : RestResponse
+	/// <summary>
+	/// A serialization-safe DTO that captures the fields of a <see cref="RestResponse"/> using
+	/// only primitive types.  RestSharp types such as <c>ContentType</c>, <c>HeaderParameter</c>,
+	/// and <c>HttpHeaderValueCollection</c> all lack parameterless constructors and cannot be
+	/// round-tripped by Newtonsoft.Json when TypeNameHandling is enabled in CluedIn Core's
+	/// JsonSerializer.  By storing only strings / enums / Uri this class is fully deserializable.
+	/// </summary>
+	public class WebRestResponse
 	{
 		public WebRestResponse()
 		{
@@ -14,20 +20,85 @@ namespace CluedIn.ExternalSearch.Providers.Web.Model
 
 		public WebRestResponse(RestResponse response)
 		{
-			this.ContentType       = response.ContentType;
-			this.ContentLength     = response.ContentLength;
-			this.ContentEncoding   = response.ContentEncoding;
-			this.Content           = response.Content;
-			this.StatusCode        = response.StatusCode;
-			this.StatusDescription = response.StatusDescription;
-			this.RawBytes          = response.RawBytes;
-			this.ResponseUri       = response.ResponseUri;
-			this.Server            = response.Server;
-			this.Cookies           = response.Cookies;
-			this.Headers           = response.Headers;
-			this.ResponseStatus    = response.ResponseStatus;
-			this.ErrorMessage      = response.ErrorMessage;
-			this.ErrorException    = response.ErrorException;
+			this.ContentType        = response.ContentType;
+			this.ContentLength      = response.ContentLength;
+			this.ContentEncoding    = [..response.ContentEncoding];
+			this.Content            = response.Content;
+			this.StatusCode         = response.StatusCode;
+			this.StatusDescription  = response.StatusDescription;
+			this.RawBytes           = response.RawBytes;
+			this.ResponseUri        = response.ResponseUri;
+			this.Server             = response.Server;
+			this.ResponseStatus     = response.ResponseStatus;
+			this.ErrorMessage       = response.ErrorMessage;
+			this.ErrorException     = response.ErrorException;
+
+			if (response.Headers != null)
+			{
+				foreach (var h in response.Headers)
+					Headers.Add(new HeaderDto { Name = h.Name, Value = h.Value });
+			}
+
+            if (response.Cookies == null) return;
+
+            foreach (var c in response.Cookies)
+            {
+                if (c is Cookie cookie)
+                    Cookies.Add(new CookieDto { Name = cookie.Name, Value = cookie.Value });
+            }
+        }
+
+		public string            ContentType       { get; set; }
+		public long?             ContentLength     { get; set; }
+		public List<string>      ContentEncoding   { get; set; } = [];
+		public string            Content           { get; set; }
+		public HttpStatusCode    StatusCode        { get; set; }
+		public string            StatusDescription { get; set; }
+		public byte[]            RawBytes          { get; set; }
+		public Uri               ResponseUri       { get; set; }
+		public string            Server            { get; set; }
+		public ResponseStatus    ResponseStatus    { get; set; }
+		public string            ErrorMessage      { get; set; }
+		public Exception         ErrorException    { get; set; }
+		public List<HeaderDto>   Headers           { get; set; } = [];
+		public List<CookieDto>   Cookies           { get; set; } = [];
+
+		/// <summary>
+		/// Reconstructs a <see cref="RestResponse"/> from the stored primitive fields so that
+		/// it can be passed to APIs that require a <see cref="RestResponse"/> instance (e.g.
+		/// <c>OrganizationWebsiteParser.Parse</c>).
+		/// </summary>
+		public RestResponse ToRestResponse()
+		{
+			var r = new RestResponse
+			{
+                ContentType = ContentType,
+                ContentLength = ContentLength,
+                ContentEncoding = ContentEncoding,
+                Content = Content,
+                StatusCode = StatusCode,
+                StatusDescription = StatusDescription,
+                RawBytes = RawBytes,
+                ResponseUri = ResponseUri,
+                Server = Server,
+                ResponseStatus = ResponseStatus,
+                ErrorMessage = ErrorMessage,
+                ErrorException = ErrorException,
+            };
+
+			return r;
+		}
+
+		public class HeaderDto
+		{
+			public string Name  { get; set; }
+			public string Value { get; set; }
+		}
+
+		public class CookieDto
+		{
+			public string Name  { get; set; }
+			public string Value { get; set; }
 		}
 	}
 }

--- a/src/ExternalSearch.Providers.Web/Model/WebResult.cs
+++ b/src/ExternalSearch.Providers.Web/Model/WebResult.cs
@@ -30,7 +30,7 @@ namespace CluedIn.ExternalSearch.Providers.Web.Model
 
             var parser = new OrganizationWebsiteParser();
 
-            this.cachedOrganizationData = parser.Parse(context, this.RequestUri, this.RestResponse);
+            this.cachedOrganizationData = parser.Parse(context, this.RequestUri, this.RestResponse.ToRestResponse());
 
             return this.cachedOrganizationData;
         }

--- a/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.Web/WebExternalSearchProvider.cs
@@ -445,5 +445,6 @@ namespace CluedIn.ExternalSearch.Providers.Web
         public IEnumerable<Control> Properties { get; } = WebExternalSearchConstants.Properties;
         public Guide Guide { get; } = WebExternalSearchConstants.Guide;
         public IntegrationType Type { get; } = WebExternalSearchConstants.IntegrationType;
+        public override Version Version => new Version("5.0.0.0"); // Update version to expire cached results when we make changes like changing the result type
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#57671](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/57671)

Able to enrich after creating a mapping class to manually map RestSharp response, checked the `header` is causing the issue, it's not being used too, therefore it will be removed from the mapping

<img width="3837" height="2072" alt="image" src="https://github.com/user-attachments/assets/c362f7a0-2ef0-429d-bda8-77987d3bc3c3" />


## How has it been tested? <!-- Remove if not needed -->
Manually in local

